### PR TITLE
Add NotFoundException with error message

### DIFF
--- a/src/main/kotlin/com/hibob/academy/employee_feedback_feature/service/FeedbackService.kt
+++ b/src/main/kotlin/com/hibob/academy/employee_feedback_feature/service/FeedbackService.kt
@@ -2,6 +2,7 @@ package com.hibob.academy.employee_feedback_feature.service
 
 import com.hibob.academy.employee_feedback_feature.dao.*
 import com.hibob.academy.employee_feedback_feature.validation.ValidateSubmission.Companion.validateTextSubmission
+import jakarta.ws.rs.NotFoundException
 import org.springframework.beans.factory.annotation.Autowired
 
 import org.springframework.stereotype.Component
@@ -33,12 +34,10 @@ class FeedbackService @Autowired constructor(private val feedbackDao: FeedbackDa
 
     fun updateFeedbackStatus(updateFeedback: UpdateFeedbackStatus, companyId: Long): String {
         val rowsAffected = feedbackDao.updateFeedbackStatus(updateFeedback, companyId)
-        val result = if (rowsAffected > 0) {
-            "Feedback status updated!"
-        } else {
-            "Feedback status not updated!"
+        if (rowsAffected > 0) {
+            return "Feedback status updated!"
         }
 
-        return result
+        throw NotFoundException("Error: Feedback status not updated! Make sure the feedback exists at your company")
     }
 }

--- a/src/test/kotlin/com/hibob/academy/employee_feedback_feature/service/FeedbackServiceTest.kt
+++ b/src/test/kotlin/com/hibob/academy/employee_feedback_feature/service/FeedbackServiceTest.kt
@@ -1,6 +1,7 @@
 package com.hibob.academy.employee_feedback_feature.service
 
 import com.hibob.academy.employee_feedback_feature.dao.*
+import jakarta.ws.rs.NotFoundException
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -41,7 +42,8 @@ class FeedbackServiceTest {
     @Test
     fun `getFeedbackStatus should return feedback status when feedback exists`() {
         val searchedFeedback = SearchedFeedback(companyId = companyId, feedbackId = 1L)
-        val feedbackData = FeedbackData(1L, employeeId, companyId, feedbackText, isAnonymous, department, LocalDateTime.now(), true)
+        val feedbackData =
+            FeedbackData(1L, employeeId, companyId, feedbackText, isAnonymous, department, LocalDateTime.now(), true)
 
         whenever(feedbackDao.getFeedbackStatus(searchedFeedback)).thenReturn(feedbackData)
 
@@ -80,9 +82,9 @@ class FeedbackServiceTest {
 
         whenever(feedbackDao.updateFeedbackStatus(updateFeedbackStatus, companyId)).thenReturn(0)
 
-        val result = feedbackService.updateFeedbackStatus(updateFeedbackStatus, companyId)
-
-        assertEquals("Feedback status not updated!", result)
+        assertThrows<NotFoundException> {
+            feedbackService.updateFeedbackStatus(updateFeedbackStatus, companyId)
+        }
     }
 
     @Test


### PR DESCRIPTION
Add NotFoundException with error message when feedback status update fails due to non-existing feedback at the company.